### PR TITLE
renaming ascii to unicode + making parseInt parse hex & binary strings

### DIFF
--- a/calculator/eval.go
+++ b/calculator/eval.go
@@ -93,7 +93,7 @@ func (s *State) Eval(curNode CalcNode) (int64, error) { //nolint:funlen,gocyclo 
 			return -1, errors.New("bad double rune operator")
 		}
 	}
-	num, err := strconv.ParseInt(*curNode.value, 10, 64)
+	num, err := strconv.ParseInt(*curNode.value, 0, 64)
 	if err != nil {
 		if *curNode.value == "_ans_" {
 			return s.Ans, nil

--- a/display.go
+++ b/display.go
@@ -60,35 +60,36 @@ func uintDisplayString(num int64) string {
 
 func hexDisplayString(num int64) string {
 	//nolint:gosec // I think it makes the most sense to display the hex value as unsigned
-	return hexString + fmt.Sprintf("%x\n", uint64(num))
+	return hexString + fmt.Sprintf("%X\n", uint64(num))
 }
 
 func displayString(num int64, err error) []string {
 	display := append([]string{
 		"",
-		ASCII(num),
+		unicodeDisplayString(num),
 		decimalDisplayString(num),
 		uintDisplayString(num),
 		hexDisplayString(num),
 	},
-		binaryDisplayStrings(num)...)
+		binaryDisplayStrings(num)...,
+	)
 	if err != nil {
 		display[0] = tcolor.Red.Foreground() + "Last input was invalid" + tcolor.Reset
 	}
 	return display
 }
 
-func ASCII(num int64) string {
+func unicodeDisplayString(num int64) string {
 	switch num {
 	case 12:
-		return "ASCII: "
+		return "Unicode: "
 	case 7:
-		return "ASCII: "
+		return "Unicode: "
 	case 10:
-		return "ASCII: \\n"
+		return "Unicode: \\n"
 	case 11:
-		return "ASCII: \\r"
+		return "Unicode: \\r"
 	default:
-		return "ASCII: " + string(rune(num))
+		return "Unicode: " + string(rune(num))
 	}
 }

--- a/tcalc_test.go
+++ b/tcalc_test.go
@@ -18,7 +18,7 @@ func TestDisplayStrings(t *testing.T) {
 	if uintString != "Unsigned Decimal: 18446744073709551552" {
 		t.Fail()
 	}
-	if ASCII(int64('a')) != "ASCII: a" {
+	if unicodeDisplayString(int64('a')) != "Unicode: a" {
 		t.Fail()
 	}
 	strs := displayString(64, errors.New("random error"))


### PR DESCRIPTION
parseInt's specified base can be set to 0 and it will automagically parse hex/decimal/octal/binary based on the string's prefix. 